### PR TITLE
Update the EYA DEF example data to align with the latest version of the Power Curve Schema

### DIFF
--- a/json_schema/examples/iec_61400-15-2_eya_def_example_a.json
+++ b/json_schema/examples/iec_61400-15-2_eya_def_example_a.json
@@ -2035,8 +2035,7 @@
         {
           "certification": {
             "certificate_reference": "IECRE.WE.TC.20.0099-R6",
-            "standard": "IEC",
-            "standard_edition": "2"
+            "design_standard": "IEC 61400-1:2019"
           },
           "design_class": {
             "class_label": "II"
@@ -2100,37 +2099,37 @@
         ]
       },
       "power_curves": {
-        "default_operating_mode": "standard",
+        "default_operating_mode_label": "standard",
         "operating_modes": [
           {
             "cuts": [
               {
-                "kind": "low_cut_in",
+                "kind": "low-cut-in",
                 "period": 600.0,
                 "wind_speed": 3.0
               },
               {
-                "kind": "low_cut_out",
+                "kind": "low-cut-out",
                 "period": 600.0,
                 "wind_speed": 2.2
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 600.0,
                 "wind_speed": 27.5
               },
               {
-                "kind": "high_cut_in",
+                "kind": "high-cut-in",
                 "period": 240.0,
                 "wind_speed": 25.0
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 30.0,
                 "wind_speed": 30.0
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 3.0,
                 "wind_speed": 35.0
               }
@@ -2353,8 +2352,8 @@
           },
           "derating": [
             {
-              "$comment": "Linear ramp down to zero",
               "air_density": 1.225,
+              "legend": "Linear ramp down to zero",
               "power_limit": [
                 5500000.0,
                 0.0
@@ -2378,8 +2377,7 @@
         {
           "certification": {
             "certificate_reference": "IECRE.WE.TC.20.0099-R6",
-            "standard": "IEC",
-            "standard_edition": "2"
+            "design_standard": "IEC 61400-1:2019"
           },
           "design_class": {
             "class_label": "II"
@@ -2443,37 +2441,37 @@
         ]
       },
       "power_curves": {
-        "default_operating_mode": "standard",
+        "default_operating_mode_label": "standard",
         "operating_modes": [
           {
             "cuts": [
               {
-                "kind": "low_cut_in",
+                "kind": "low-cut-in",
                 "period": 600.0,
                 "wind_speed": 3.0
               },
               {
-                "kind": "low_cut_out",
+                "kind": "low-cut-out",
                 "period": 600.0,
                 "wind_speed": 2.2
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 600.0,
                 "wind_speed": 26.0
               },
               {
-                "kind": "high_cut_in",
+                "kind": "high-cut-in",
                 "period": 240.0,
                 "wind_speed": 24.0
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 30.0,
                 "wind_speed": 28.0
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 3.0,
                 "wind_speed": 32.0
               }
@@ -2685,8 +2683,8 @@
           },
           "derating": [
             {
-              "$comment": "Linear ramp down to zero",
               "air_density": 1.225,
+              "legend": "Linear ramp down to zero",
               "power_limit": [
                 5800000.0,
                 0.0
@@ -2710,8 +2708,7 @@
         {
           "certification": {
             "certificate_reference": "IECRE.WE.TC.20.0099-R6",
-            "standard": "IEC",
-            "standard_edition": "2"
+            "design_standard": "IEC 61400-1:2019"
           },
           "design_class": {
             "class_label": "II"
@@ -2775,37 +2772,37 @@
         ]
       },
       "power_curves": {
-        "default_operating_mode": "standard",
+        "default_operating_mode_label": "standard",
         "operating_modes": [
           {
             "cuts": [
               {
-                "kind": "low_cut_in",
+                "kind": "low-cut-in",
                 "period": 600.0,
                 "wind_speed": 3.0
               },
               {
-                "kind": "low_cut_out",
+                "kind": "low-cut-out",
                 "period": 600.0,
                 "wind_speed": 2.5
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 600.0,
                 "wind_speed": 25.0
               },
               {
-                "kind": "high_cut_in",
+                "kind": "high-cut-in",
                 "period": 300.0,
                 "wind_speed": 22.0
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 30.0,
                 "wind_speed": 28.0
               },
               {
-                "kind": "high_cut_out",
+                "kind": "high-cut-out",
                 "period": 3.0,
                 "wind_speed": 32.0
               }
@@ -3008,8 +3005,8 @@
           },
           "derating": [
             {
-              "$comment": "Linear ramp down to zero",
               "air_density": 1.225,
+              "legend": "Linear ramp down to zero",
               "power_limit": [
                 3200000.0,
                 0.0

--- a/json_schema/examples/iec_61400-15-2_eya_def_example_a_ABC165-5.5MW.json
+++ b/json_schema/examples/iec_61400-15-2_eya_def_example_a_ABC165-5.5MW.json
@@ -3,8 +3,7 @@
     {
       "certification": {
         "certificate_reference": "IECRE.WE.TC.20.0099-R6",
-        "standard": "IEC",
-        "standard_edition": "2"
+        "design_standard": "IEC 61400-1:2019"
       },
       "design_class": {
         "class_label": "II"
@@ -68,37 +67,37 @@
     ]
   },
   "power_curves": {
-    "default_operating_mode": "standard",
+    "default_operating_mode_label": "standard",
     "operating_modes": [
       {
         "cuts": [
           {
-            "kind": "low_cut_in",
+            "kind": "low-cut-in",
             "period": 600.0,
             "wind_speed": 3.0
           },
           {
-            "kind": "low_cut_out",
+            "kind": "low-cut-out",
             "period": 600.0,
             "wind_speed": 2.2
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 600.0,
             "wind_speed": 27.5
           },
           {
-            "kind": "high_cut_in",
+            "kind": "high-cut-in",
             "period": 240.0,
             "wind_speed": 25.0
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 30.0,
             "wind_speed": 30.0
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 3.0,
             "wind_speed": 35.0
           }
@@ -321,8 +320,8 @@
       },
       "derating": [
         {
-          "$comment": "Linear ramp down to zero",
           "air_density": 1.225,
+          "legend": "Linear ramp down to zero",
           "power_limit": [
             5500000.0,
             0.0

--- a/json_schema/examples/iec_61400-15-2_eya_def_example_a_PQR169-5.8MW.json
+++ b/json_schema/examples/iec_61400-15-2_eya_def_example_a_PQR169-5.8MW.json
@@ -3,8 +3,7 @@
     {
       "certification": {
         "certificate_reference": "IECRE.WE.TC.20.0099-R6",
-        "standard": "IEC",
-        "standard_edition": "2"
+        "design_standard": "IEC 61400-1:2019"
       },
       "design_class": {
         "class_label": "II"
@@ -68,37 +67,37 @@
     ]
   },
   "power_curves": {
-    "default_operating_mode": "standard",
+    "default_operating_mode_label": "standard",
     "operating_modes": [
       {
         "cuts": [
           {
-            "kind": "low_cut_in",
+            "kind": "low-cut-in",
             "period": 600.0,
             "wind_speed": 3.0
           },
           {
-            "kind": "low_cut_out",
+            "kind": "low-cut-out",
             "period": 600.0,
             "wind_speed": 2.2
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 600.0,
             "wind_speed": 26.0
           },
           {
-            "kind": "high_cut_in",
+            "kind": "high-cut-in",
             "period": 240.0,
             "wind_speed": 24.0
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 30.0,
             "wind_speed": 28.0
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 3.0,
             "wind_speed": 32.0
           }
@@ -310,8 +309,8 @@
       },
       "derating": [
         {
-          "$comment": "Linear ramp down to zero",
           "air_density": 1.225,
+          "legend": "Linear ramp down to zero",
           "power_limit": [
             5800000.0,
             0.0

--- a/json_schema/examples/iec_61400-15-2_eya_def_example_a_XYZ-3.2_140.json
+++ b/json_schema/examples/iec_61400-15-2_eya_def_example_a_XYZ-3.2_140.json
@@ -3,8 +3,7 @@
     {
       "certification": {
         "certificate_reference": "IECRE.WE.TC.20.0099-R6",
-        "standard": "IEC",
-        "standard_edition": "2"
+        "design_standard": "IEC 61400-1:2019"
       },
       "design_class": {
         "class_label": "II"
@@ -68,37 +67,37 @@
     ]
   },
   "power_curves": {
-    "default_operating_mode": "standard",
+    "default_operating_mode_label": "standard",
     "operating_modes": [
       {
         "cuts": [
           {
-            "kind": "low_cut_in",
+            "kind": "low-cut-in",
             "period": 600.0,
             "wind_speed": 3.0
           },
           {
-            "kind": "low_cut_out",
+            "kind": "low-cut-out",
             "period": 600.0,
             "wind_speed": 2.5
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 600.0,
             "wind_speed": 25.0
           },
           {
-            "kind": "high_cut_in",
+            "kind": "high-cut-in",
             "period": 300.0,
             "wind_speed": 22.0
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 30.0,
             "wind_speed": 28.0
           },
           {
-            "kind": "high_cut_out",
+            "kind": "high-cut-out",
             "period": 3.0,
             "wind_speed": 32.0
           }
@@ -301,8 +300,8 @@
       },
       "derating": [
         {
-          "$comment": "Linear ramp down to zero",
           "air_density": 1.225,
+          "legend": "Linear ramp down to zero",
           "power_limit": [
             3200000.0,
             0.0


### PR DESCRIPTION
The Power Curve Schema is still undergoing review and development. There has been some recent changes that the EYA DEF examples need to align with. This PR brings the examples in the EYA DEF repository up-to-date with the latest version of the Power Curve Schema.