### PR TITLE
Fix typo in parser.py docstring

### DIFF
--- a/eya_def_tools/eya_def_tools/io/parser.py
+++ b/eya_def_tools/eya_def_tools/io/parser.py
@@ -16,7 +16,7 @@ def parse_file(filepath: Path) -> EyaDefDocument:
     documents as JSON rather than YAML to ensure safe serialization and
     deserialization without compatibility issues.
 
-    :param filepath: the path to the file to pase
+    :param filepath: the path to the file to parse
     :return: an ``EyaDefDocument`` instance representation of the file
         contents
     """


### PR DESCRIPTION
Change "pase" to "parse" in the parse_file function docstring parameter description for improved documentation clarity.